### PR TITLE
tangd: Overwrite ListenStream instead of extending it

### DIFF
--- a/manifests/dropin.pp
+++ b/manifests/dropin.pp
@@ -5,6 +5,6 @@ class tang::dropin {
 
   systemd::dropin_file { 'override.conf':
     unit    => 'tangd.socket',
-    content => "[Socket]\nListenStream=7500\n",
+    content => "[Socket]\nListenStream=\nListenStream=7500\n",
   }
 }


### PR DESCRIPTION
If in a systemd dropin a value isn't set to empty first like `ListenStream=`, another value won't overwrite the initial one, it will extend it.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
