### PR TITLE
(metadata.json) bump systemd to include 8.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,7 @@
     },
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 5.0.0 < 8.0.0"
+      "version_requirement": ">= 5.0.0 < 9.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Bump systemd version constraint to include 8.x

#### This Pull Request (PR) fixes the following issues
I am aware of this PR: https://github.com/voxpupuli/puppet-tang/pull/33 that is currently failing CI, so this seeks to remediate that.